### PR TITLE
config.assets.initialize_on_precompile = falseをコメントアウトしてみた

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,7 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-config.assets.initialize_on_precompile = false
+#config.assets.initialize_on_precompile = false
 
 module Myapp
   class Application < Rails::Application


### PR DESCRIPTION
docker-compose upをする時に
undefined local variable or method `config' for main:Object (NameError)
が出たため試しに修正